### PR TITLE
remove ubuntu precise from testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Uses `systemd-resolved` or `network-manager` if installed, else it removes `reso
 Version
 -------
 
+* `1.2.0` --- remove ubuntu precise from testing
 * `1.1.1` --- fixed lint warnings
 * `1.1.0` --- added ubuntu focal, 20.04
 * `1.0.4` --- tested with Ansible 2.9.11
@@ -23,7 +24,6 @@ Requirements
 
 This role is limited to:
 
-* Ubuntu 12.04
 * Ubuntu 14.04
 * Ubuntu 16.04
 * Ubuntu 18.04

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -9,7 +9,6 @@ Vagrant.configure("2") do |config|
     { :name => "bionic", :box => "ubuntu/bionic64" },
     { :name => "xenial", :box => "ubuntu/xenial64" },
     { :name => "trusty", :box => "ubuntu/trusty64" },
-    { :name => "precise", :box => "ubuntu/precise64" },
     { :name => "centos8", :box => "centos/8" },
     { :name => "centos7", :box => "centos/7" },
     { :name => "centos6", :box => "centos/6" },


### PR DESCRIPTION
Hi!

I'd like to contribute feature.

Ubuntu isn't publishing the old Precise image on Vagrant Cloud anymore.

* [ ] I have read and accepted both license and code of conduct.
* [x] I have previously accepted and still accept both license and code of conduct.
