### PR TITLE
minor fix: systemd-resolve process check name

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   register: network_manager_running
   check_mode: false
 
-- name: Check if network manager runs
+- name: Check if systemd-resolve runs
   ansible.builtin.shell: pgrep systemd-resolve
   failed_when: false
   changed_when: false


### PR DESCRIPTION
Hi!

I'd like to contribute documentation.

Currently the task that registers the variable thats used to check if systemd-resolve is running is called "Check if network manager runs", which was most likely a copy & paste error.

I confirm that my contributions will be compatible with the GPLv2.0 license guidelines.

* [x] I have read and accepted both license and code of conduct.
* [x] I have previously accepted and still accept both license and code of conduct.
